### PR TITLE
Added missing device parameter to PyTorch layer constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ resize_reight.resize(input, scale_factors=None, out_shape=None,
 ```
 For a PyTorch layer (nn.Module):
 ```
-resize_layer = resize_reight.ResizeLayer(in_shape, scale_factors=None, out_shape=None,
-                                         interp_method=interp_methods.cubic, support_sz=None,
-                                         antialiasing=True
+resize_layer = resize_right.ResizeLayer(in_shape, scale_factors=None, out_shape=None,
+                                        interp_method=interp_methods.cubic, support_sz=None,
+                                        antialiasing=True, device=torch.device('cuda'))
                            
 resize_layer(input)
 ```

--- a/resize_right.py
+++ b/resize_right.py
@@ -79,7 +79,7 @@ def resize(input, scale_factors=None, out_shape=None,
 class ResizeLayer(nnModuleWrapped):
     def __init__(self, in_shape, scale_factors=None, out_shape=None,
                  interp_method=interp_methods.cubic, support_sz=None,
-                 antialiasing=True):
+                 antialiasing=True, device=None):
         super(ResizeLayer, self).__init__()
 
         # fw stands for framework, that can be either numpy or torch. since
@@ -117,7 +117,7 @@ class ResizeLayer(nnModuleWrapped):
             # location along this dim
             field_of_view, weights = prepare_weights_and_field_of_view_1d(
                 dim, scale_factor, in_shape[dim], out_shape[dim],
-                interp_method, support_sz, antialiasing, fw, eps, input.device)
+                interp_method, support_sz, antialiasing, fw, eps, device)
 
             # keep weights and fields of views for all dims
             weights_list.append(nn.Parameter(weights, requires_grad=False))


### PR DESCRIPTION
The nn.Layer constructor tries to use `input.device`, which doesn't exist, resulting in a crash.
Added an explicit device parameter to the constructor.