### PR TITLE
fix some bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ __antialiasing__:
 This is an option similar to MATLAB's default. only relevant for downscaling. if true it basicly means that the kernel is stretched with 1/scale_factor to prevent aliasing (low-pass filtering)
 
 __by_convs__:
-This determines whether to allow efficient calculation using convolutions according to tolerance. This feature should be used when scale_factor(out_size / in_size) is rational with a numerator low enough (or close enough to being an integer) and the tensors are big (batches or high-resolution).
+This determines whether to allow efficient calculation using convolutions according to tolerance. This feature should be used when scale_factor is rational with a numerator low enough (or close enough to being an integer) and the tensors are big (batches or high-resolution).
 
 __scale_tolerance__:
 This is the allowed distance between the M/N closest frac to the float scale_factore provided. if the frac is closer than this distance, then it will be used and efficient convolution calculation will take place.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For dynamic resize using either Numpy or PyTorch:
 resize_right.resize(input, scale_factors=None, out_shape=None,
                     interp_method=interp_methods.cubic, support_sz=None,
                     antialiasing=True, by_convs=False, scale_tolerance=None,
-                    max_denominator=10, pad_mode='constant'):
+                    max_numerator=10, pad_mode='constant'):
 ```
 
 __input__ :   
@@ -62,13 +62,13 @@ __antialiasing__:
 This is an option similar to MATLAB's default. only relevant for downscaling. if true it basicly means that the kernel is stretched with 1/scale_factor to prevent aliasing (low-pass filtering)
 
 __by_convs__:
-This determines whether to allow efficient calculation using convolutions according to tolerance. This feature should be used when scale_factor * in_size is rational with a denominator low enough (or close enough to being an integer) and the tensors are big (batches or high-resolution).
+This determines whether to allow efficient calculation using convolutions according to tolerance. This feature should be used when scale_factor(out_size / in_size) is rational with a numerator low enough (or close enough to being an integer) and the tensors are big (batches or high-resolution).
 
 __scale_tolerance__:
 This is the allowed distance between the M/N closest frac to the float scale_factore provided. if the frac is closer than this distance, then it will be used and efficient convolution calculation will take place.
 
-__max_denominator__:
-When by_convs is on, the scale_factor is translated to a rational frac M/N. Where M is limited by this parameter. The goal is to make the calculation more efficient. The number of convolutions used is the size of the denominator.
+__max_numerator__:
+When by_convs is on, the scale_factor is translated to a rational frac M/N. Where M is limited by this parameter. The goal is to make the calculation more efficient. The number of convolutions used is the size of the numerator.
 
 __pad_mode__:
 This can be used according to the padding methods of each framework.

--- a/resize_right.py
+++ b/resize_right.py
@@ -32,7 +32,7 @@ if numpy is None and torch is None:
 def resize(input, scale_factors=None, out_shape=None,
            interp_method=interp_methods.cubic, support_sz=None,
            antialiasing=True, by_convs=False, scale_tolerance=None,
-           max_denominator=10, pad_mode='constant'):
+           max_numerator=10, pad_mode='constant'):
     # get properties of the input tensor
     in_shape, n_dims = input.shape, input.ndim
 
@@ -50,7 +50,7 @@ def resize(input, scale_factors=None, out_shape=None,
                                                               scale_factors,
                                                               by_convs,
                                                               scale_tolerance,
-                                                              max_denominator,
+                                                              max_numerator,
                                                               eps, fw)
 
     # sort indices of dimensions according to scale of each dimension.
@@ -281,7 +281,7 @@ def apply_convs(input, scale_factor, in_sz, out_sz, weights, dim, pad_sz,
 
 
 def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
-                         scale_tolerance, max_denominator, eps, fw):
+                         scale_tolerance, max_numerator, eps, fw):
     # eventually we must have both scale-factors and out-sizes for all in/out
     # dims. however, we support many possible partial arguments
     if scale_factors is None and out_shape is None:
@@ -327,7 +327,7 @@ def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
         for ind, (sf, dim_by_convs) in enumerate(zip(scale_factors, by_convs)):
             # first we fractionaize
             if dim_by_convs:
-                frac = Fraction(1/sf).limit_denominator(max_denominator)
+                frac = Fraction(1/sf).limit_denominator(max_numerator)
                 frac = Fraction(numerator=frac.denominator, denominator=frac.numerator)
 
             # if accuracy is within tolerance scale will be frac. if not, then

--- a/resize_right.py
+++ b/resize_right.py
@@ -196,8 +196,6 @@ def calc_pad_sz(in_sz, out_sz, field_of_view, projected_grid, scale_factor,
         # in the by_convs case pad_sz is a list of left-right pairs. one per
         # each filter
 
-        # pad_sz = [(left_pad, right_pad) for (left_pad, right_pad) in
-        #           zip(left_pads, right_pads)]
         pad_sz = list(zip(left_pads, right_pads))
 
     return pad_sz, projected_grid, field_of_view
@@ -262,7 +260,6 @@ def apply_convs(input, scale_factor, in_sz, out_sz, weights, dim, pad_sz,
     # prepare an empty tensor for the output
     tmp_out_shape = list(input.shape)
     tmp_out_shape[-1] = out_sz
-    #tmp_output = fw_empty((*tmp_out_shape,), fw, input.device)
     tmp_output = fw_empty(tuple(tmp_out_shape), fw, input.device)
 
     # iterate over the conv operations. we have as many as the numerator
@@ -319,7 +316,6 @@ def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
         # next part intentionally after out_shape determined for stability
         # we fix by_convs to be a list of truth values in case it is not
         if not isinstance(by_convs, (list, tuple)):
-            #by_convs = [by_convs for _ in range(len(out_shape))]
             by_convs = [by_convs] * len(out_shape)
 
         # next loop fixes the scale for each dim to be either frac or float.
@@ -391,7 +387,6 @@ def fw_pad(x, fw, pad_sz, pad_mode, dim=0):
     if pad_sz == (0, 0):
         return x
     if fw is numpy:
-        #pad_vec = [(0, 0) for _ in range(x.ndim)]
         pad_vec = [(0, 0)] * x.ndim
         pad_vec[dim] = pad_sz
         return fw.pad(x, pad_width=pad_vec, mode=pad_mode)
@@ -399,17 +394,6 @@ def fw_pad(x, fw, pad_sz, pad_mode, dim=0):
         if x.ndim < 3:
             x = x[None, None, ...]
 
-        # >>> timeit("list(0 for i in range(0, 100000))", number=1000)
-        # 4.084772332999989
-        # >>> timeit("[0 for i in range(0, 100000)]", number=1000)
-        # 2.9616422500000112
-        # >>> timeit("[0] * 100000", number=1000)
-        # 0.2548029160000169
-        # >>> timeit('list(itertools.repeat(0, 100000))', 'import itertools', number=1000)
-        # 0.5355214580000052
-
-        #pad_vec = [0 for _ in range((x.ndim - 2) * 2)]
-        # we use fastest method to generate list of zeros
         pad_vec = [0] * ((x.ndim - 2) * 2)
         pad_vec[0:2] = pad_sz
         return fw.nn.functional.pad(x.transpose(dim, -1), pad=pad_vec,

--- a/resize_right.py
+++ b/resize_right.py
@@ -31,7 +31,7 @@ if numpy is None and torch is None:
 def resize(input, scale_factors=None, out_shape=None,
            interp_method=interp_methods.cubic, support_sz=None,
            antialiasing=True, by_convs=False, scale_tolerance=None,
-           max_denominator=10, pad_mode='constant'):
+           max_numerator=10, pad_mode='constant'):
     # get properties of the input tensor
     in_shape, n_dims = input.shape, input.ndim
 
@@ -49,7 +49,7 @@ def resize(input, scale_factors=None, out_shape=None,
                                                               scale_factors,
                                                               by_convs,
                                                               scale_tolerance,
-                                                              max_denominator,
+                                                              max_numerator,
                                                               eps, fw)
 
     # sort indices of dimensions according to scale of each dimension.
@@ -259,7 +259,7 @@ def apply_convs(input, scale_factor, in_sz, out_sz, weights, dim, pad_sz,
     # prepare an empty tensor for the output
     tmp_out_shape = list(input.shape)
     tmp_out_shape[-1] = out_sz
-    tmp_output = fw_empty((*tmp_out_shape,), fw, input.device)
+    tmp_output = fw_empty(tuple(tmp_out_shape), fw, input.device)
 
     # iterate over the conv operations. we have as many as the numerator
     # of the scale-factor. for each we need boundaries and a filter.
@@ -277,7 +277,7 @@ def apply_convs(input, scale_factor, in_sz, out_sz, weights, dim, pad_sz,
 
 
 def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
-                         scale_tolerance, max_denominator, eps, fw):
+                         scale_tolerance, max_numerator, eps, fw):
     # eventually we must have both scale-factors and out-sizes for all in/out
     # dims. however, we support many possible partial arguments
     if scale_factors is None and out_shape is None:
@@ -286,7 +286,7 @@ def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
     if out_shape is not None:
         # if out_shape has less dims than in_shape, we defaultly resize the
         # first dims for numpy and last dims for torch
-        out_shape = (list(out_shape) + list(in_shape[:-len(out_shape)])
+        out_shape = (list(out_shape) + list(in_shape[len(out_shape):])
                      if fw is numpy
                      else list(in_shape[:-len(out_shape)]) + list(out_shape))
         if scale_factors is None:
@@ -322,7 +322,8 @@ def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
         for ind, (sf, dim_by_convs) in enumerate(zip(scale_factors, by_convs)):
             # first we fractionaize
             if dim_by_convs:
-                frac = Fraction(sf).limit_denominator(max_denominator)
+                frac = Fraction(1/sf).limit_denominator(max_numerator)
+                frac = Fraction(numerator=frac.denominator, denominator=frac.numerator)
 
             # if accuracy is within tolerance scale will be frac. if not, then
             # it will be float and the by_convs attr will be set false for

--- a/resize_right.py
+++ b/resize_right.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import warnings
 from math import ceil
 import interp_methods
@@ -31,7 +32,7 @@ if numpy is None and torch is None:
 def resize(input, scale_factors=None, out_shape=None,
            interp_method=interp_methods.cubic, support_sz=None,
            antialiasing=True, by_convs=False, scale_tolerance=None,
-           max_numerator=10, pad_mode='constant'):
+           max_denominator=10, pad_mode='constant'):
     # get properties of the input tensor
     in_shape, n_dims = input.shape, input.ndim
 
@@ -49,7 +50,7 @@ def resize(input, scale_factors=None, out_shape=None,
                                                               scale_factors,
                                                               by_convs,
                                                               scale_tolerance,
-                                                              max_numerator,
+                                                              max_denominator,
                                                               eps, fw)
 
     # sort indices of dimensions according to scale of each dimension.
@@ -104,7 +105,7 @@ def resize(input, scale_factors=None, out_shape=None,
                                                             device)
 
         # STEP 3- CALCULATE WEIGHTS: Match a set of weights to the pixels in
-        # the# field of view for each output pixel
+        # the field of view for each output pixel
         weights = get_weights(cur_interp_method, projected_grid, field_of_view)
 
         # STEP 4- APPLY WEIGHTS: Each output pixel is calculated by multiplying
@@ -170,7 +171,7 @@ def calc_pad_sz(in_sz, out_sz, field_of_view, projected_grid, scale_factor,
         # calculate left and right boundaries for each conv. left can also be
         # negative right can be bigger than in_sz. such cases imply padding if
         # needed. however if# both are in-bounds, it means we need to crop,
-        # pracitacally apply the conv only on part of the image.
+        # practically apply the conv only on part of the image.
         left_pads = -field_of_view[:, 0]
 
         # next calc is tricky, explanation by rows:
@@ -194,8 +195,10 @@ def calc_pad_sz(in_sz, out_sz, field_of_view, projected_grid, scale_factor,
 
         # in the by_convs case pad_sz is a list of left-right pairs. one per
         # each filter
-        pad_sz = [(left_pad, right_pad) for (left_pad, right_pad) in
-                  zip(left_pads, right_pads)]
+
+        # pad_sz = [(left_pad, right_pad) for (left_pad, right_pad) in
+        #           zip(left_pads, right_pads)]
+        pad_sz = list(zip(left_pads, right_pads))
 
     return pad_sz, projected_grid, field_of_view
 
@@ -259,6 +262,7 @@ def apply_convs(input, scale_factor, in_sz, out_sz, weights, dim, pad_sz,
     # prepare an empty tensor for the output
     tmp_out_shape = list(input.shape)
     tmp_out_shape[-1] = out_sz
+    #tmp_output = fw_empty((*tmp_out_shape,), fw, input.device)
     tmp_output = fw_empty(tuple(tmp_out_shape), fw, input.device)
 
     # iterate over the conv operations. we have as many as the numerator
@@ -277,7 +281,7 @@ def apply_convs(input, scale_factor, in_sz, out_sz, weights, dim, pad_sz,
 
 
 def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
-                         scale_tolerance, max_numerator, eps, fw):
+                         scale_tolerance, max_denominator, eps, fw):
     # eventually we must have both scale-factors and out-sizes for all in/out
     # dims. however, we support many possible partial arguments
     if scale_factors is None and out_shape is None:
@@ -315,14 +319,15 @@ def set_scale_and_out_sz(in_shape, out_shape, scale_factors, by_convs,
         # next part intentionally after out_shape determined for stability
         # we fix by_convs to be a list of truth values in case it is not
         if not isinstance(by_convs, (list, tuple)):
-            by_convs = [by_convs for _ in range(len(out_shape))]
+            #by_convs = [by_convs for _ in range(len(out_shape))]
+            by_convs = [by_convs] * len(out_shape)
 
         # next loop fixes the scale for each dim to be either frac or float.
         # this is determined by by_convs and by tolerance for scale accuracy.
         for ind, (sf, dim_by_convs) in enumerate(zip(scale_factors, by_convs)):
             # first we fractionaize
             if dim_by_convs:
-                frac = Fraction(1/sf).limit_denominator(max_numerator)
+                frac = Fraction(1/sf).limit_denominator(max_denominator)
                 frac = Fraction(numerator=frac.denominator, denominator=frac.numerator)
 
             # if accuracy is within tolerance scale will be frac. if not, then
@@ -386,13 +391,26 @@ def fw_pad(x, fw, pad_sz, pad_mode, dim=0):
     if pad_sz == (0, 0):
         return x
     if fw is numpy:
-        pad_vec = [(0, 0) for _ in range(x.ndim)]
+        #pad_vec = [(0, 0) for _ in range(x.ndim)]
+        pad_vec = [(0, 0)] * x.ndim
         pad_vec[dim] = pad_sz
         return fw.pad(x, pad_width=pad_vec, mode=pad_mode)
     else:
         if x.ndim < 3:
             x = x[None, None, ...]
-        pad_vec = [0 for _ in range((x.ndim - 2) * 2)]
+
+        # >>> timeit("list(0 for i in range(0, 100000))", number=1000)
+        # 4.084772332999989
+        # >>> timeit("[0 for i in range(0, 100000)]", number=1000)
+        # 2.9616422500000112
+        # >>> timeit("[0] * 100000", number=1000)
+        # 0.2548029160000169
+        # >>> timeit('list(itertools.repeat(0, 100000))', 'import itertools', number=1000)
+        # 0.5355214580000052
+
+        #pad_vec = [0 for _ in range((x.ndim - 2) * 2)]
+        # we use fastest method to generate list of zeros
+        pad_vec = [0] * ((x.ndim - 2) * 2)
         pad_vec[0:2] = pad_sz
         return fw.nn.functional.pad(x.transpose(dim, -1), pad=pad_vec,
                                     mode=pad_mode).transpose(dim, -1)


### PR DESCRIPTION
I found two bugs in the original codes and fixed them.

1: In `set_scale_and_out_sz` function, when out_shape is not None, the out_shape should be `list(out_shape) + list(in_shape[len(out_shape):])` when backbend is numpy, since we need retain last dims.

2: Also in `set_scale_and_out_sz` function. The number of conv or period is the numerator of scale_factor other than the denominator, so we should find an approximate fraction with a limited numerator.